### PR TITLE
BuildScript: Removed blank line before <?php

### DIFF
--- a/build/dist/init_bsdistribution_from_git.bash
+++ b/build/dist/init_bsdistribution_from_git.bash
@@ -181,7 +181,6 @@ done
 SETTINGS_FILE="../LocalSettings.BlueSpiceDistribution.php.template"
 rm $SETTINGS_FILE
 cat <<EOT >> $SETTINGS_FILE
-
 <?php
 //Copy LocalSettings.BlueSpiceDistribution.php.template to LocalSettings.BlueSpiceDistribution.php
 //Include LocalSettings.BlueSpiceProDistribution.php in LocalSettings.php to activate all Modules

--- a/build/dist/init_bsdistribution_from_git_http.bash
+++ b/build/dist/init_bsdistribution_from_git_http.bash
@@ -183,7 +183,6 @@ done
 SETTINGS_FILE="../LocalSettings.BlueSpiceDistribution.php.template"
 rm $SETTINGS_FILE
 cat <<EOT >> $SETTINGS_FILE
-
 <?php
 //Copy LocalSettings.BlueSpiceDistribution.php.template to LocalSettings.BlueSpiceDistribution.php
 //Include LocalSettings.BlueSpiceProDistribution.php in LocalSettings.php to activate all Modules


### PR DESCRIPTION
The produced distribution template had an empty line at the beginning
of the file. This lead to a blank line before any output of php and
destroyed all images sent via SecureFileStore
